### PR TITLE
fix(database): Default account type is now, 'consumer' instead of 'user' to bring things back in line with nomanclature

### DIFF
--- a/migrations/20210814_01_xwCee_add_role_column_to_accounts_table.py
+++ b/migrations/20210814_01_xwCee_add_role_column_to_accounts_table.py
@@ -6,7 +6,7 @@ __depends__ = {'20210322_01_In37S-add-account-field'}
 
 steps = [
     step(
-    "ALTER TABLE account ADD COLUMN  role varchar DEFAULT 'user';",
+    "ALTER TABLE account ADD COLUMN  role varchar DEFAULT 'consumer';",
 
     "ALTER TABLE account DROP COLUMN role;"
     )


### PR DESCRIPTION
Fixes an issue where if an account was not set, the account would be set to type 'user' instead of 'consumer'. 